### PR TITLE
Add Golang platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@ _Adds the "gocall" calling convention_
 
 ## Description:
 
-Adds support for the calling convention used by the Go Programming Language. Use *Go > Set Go calling convention* after loading the binary (ideally with analysis hold enabled and ensuring that all functions are created either automatically or by running another plugin to recover the symbols).
+Adds support for the calling convention used by the Go Programming Language.
+
+Golang binaries should be auto-detected and the platform set to `go-linux-x86_64`. If not, use 'Open With Options' to manually set the platform.
 
 
 **Before**
-![](https://github.com/PistonMiner/binaryninja-go-callconv/blob/main/media/before.png?raw=true)
+![](media/before.png)
 
 **After**
-![](https://github.com/PistonMiner/binaryninja-go-callconv/blob/main/media/after.png?raw=true)
+![](media/after.png)
 
 ## Minimum Version
 

--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,11 @@ class GoCall_X86_64(CallingConvention):
     int_return_reg = "rax"
     high_int_return_reg = "rbx"
 
+    def perform_get_incoming_reg_value(self, reg: RegisterName, _: Function) -> RegisterValue:
+        if reg in ["zmm15", "ymm15", "xmm15"]:
+            return variable.ConstantRegisterValue(0)
+        return variable.Undetermined()
+
 cc = GoCall_X86_64(arch=Architecture["x86_64"], name="gocall")
 Architecture["x86_64"].register_calling_convention(cc)
 

--- a/go-linux-x86_64.c
+++ b/go-linux-x86_64.c
@@ -1,0 +1,76 @@
+// https://go.dev/src/runtime/runtime2.go
+struct g {
+    // Stack parameters
+    void* stack;
+    void* stackguard0;
+    void* stackguard1;
+
+    // Inner structures
+    struct _panic* _panic;
+    struct _defer* _defer;
+    struct m* m;
+    void* sched;
+    void* syscallsp;
+    void* syscallpc;
+    void* syscallbp;
+    void* stktopsp;
+
+    // Generic parameter field
+    void* param;
+    void* atomicstatus;
+    uint32_t stackLock;
+    uint64_t goid;
+    void* schedlink;
+    int64_t waitsince;
+    void* waitreason;
+
+    // Preemption-related fields
+    bool preempt;
+    bool preemptStop;
+    bool preemptShrink;
+
+    bool asyncSafePoint;
+
+    // Additional flags and states
+    bool paniconfault;
+    bool gcscandone;
+    bool throwsplit;
+    bool activeStackChans;
+    void* parkingOnChan;
+    bool inMarkAssist;
+    bool coroexit;
+
+    int8_t raceignore;
+    bool nocgocallback;
+    bool tracking;
+    uint8_t trackingSeq;
+    int64_t trackingStamp;
+    int64_t runnableTime;
+    void* lockedm;
+    uint32_t sig;
+    void* writebuf;
+    void* sigcode0;
+    void* sigcode1;
+    void* sigpc;
+    uint64_t parentGoid;
+    void* gopc;
+    void* ancestors;
+    void* startpc;
+    void* racectx;
+    struct sudog* waiting;
+    void* cgoCtxt;
+    void* labels;
+    struct timer* timer;
+    int64_t sleepWhen;
+    void* selectDone;
+
+    void* goroutineProfiled;
+
+    struct coro* coroarg;
+
+    // Per-G tracer state
+    void* trace;
+
+    // Per-G GC state
+    int64_t gcAssistBytes;
+};


### PR DESCRIPTION
This means that binaries are automatically recognized as Golang and the convention is applied automatically without requiring reanalysis, and the `__callingconv('golang')` attribute is hidden.

I've also added a type for the `g` struct so the reads from r14 (i.e. for stack checking) are more readable.
![image](https://github.com/user-attachments/assets/86c227c3-7d0e-4156-8de0-a4d6536d8384)
